### PR TITLE
feat: add transparent background option and improve luminance calculation for starfield and starfield-colors

### DIFF
--- a/starfield-colors.glsl
+++ b/starfield-colors.glsl
@@ -1,3 +1,9 @@
+// transparent background
+const bool transparent = false;
+
+// terminal contents luminance threshold to be considered background (0.0 to 1.0)
+const float threshold = 0.15;
+
 // divisions of grid
 const float repeats = 30.;
 
@@ -5,30 +11,34 @@ const float repeats = 30.;
 const float layers = 21.;
 
 // star colours
-const vec3 blue = vec3(51.,64.,195.)/255.;
-const vec3 cyan = vec3(117.,250.,254.)/255.;
-const vec3 white = vec3(255.,255.,255.)/255.;
-const vec3 yellow = vec3(251.,245.,44.)/255.;
-const vec3 red = vec3(247,2.,20.)/255.;
+const vec3 blue = vec3(51., 64., 195.) / 255.;
+const vec3 cyan = vec3(117., 250., 254.) / 255.;
+const vec3 white = vec3(255., 255., 255.) / 255.;
+const vec3 yellow = vec3(251., 245., 44.) / 255.;
+const vec3 red = vec3(247, 2., 20.) / 255.;
+
+float luminance(vec3 color) {
+    return dot(color, vec3(0.2126, 0.7152, 0.0722));
+}
 
 // spectrum function
-vec3 spectrum(vec2 pos){
+vec3 spectrum(vec2 pos) {
     pos.x *= 4.;
     vec3 outCol = vec3(0);
-    if( pos.x > 0.){
+    if (pos.x > 0.) {
         outCol = mix(blue, cyan, fract(pos.x));
     }
-    if( pos.x > 1.){
+    if (pos.x > 1.) {
         outCol = mix(cyan, white, fract(pos.x));
     }
-    if( pos.x > 2.){
+    if (pos.x > 2.) {
         outCol = mix(white, yellow, fract(pos.x));
     }
-    if( pos.x > 3.){
+    if (pos.x > 3.) {
         outCol = mix(yellow, red, fract(pos.x));
     }
-    
-    return 1.-(pos.y * (1.-outCol));
+
+    return 1. - (pos.y * (1. - outCol));
 }
 
 float N21(vec2 p) {
@@ -44,7 +54,7 @@ vec2 N22(vec2 p) {
 
 mat2 scale(vec2 _scale) {
     return mat2(_scale.x, 0.0,
-                0.0, _scale.y);
+        0.0, _scale.y);
 }
 
 // 2D Noise based on Morgan McGuire
@@ -63,8 +73,8 @@ float noise(in vec2 st) {
 
     // Mix 4 corners percentages
     return mix(a, b, u.x) +
-           (c - a) * u.y * (1.0 - u.x) +
-           (d - b) * u.x * u.y;
+        (c - a) * u.y * (1.0 - u.x) +
+        (d - b) * u.x * u.y;
 }
 
 float perlin2(vec2 uv, int octaves, float pscale) {
@@ -103,7 +113,7 @@ vec3 stars(vec2 uv, float offset) {
 
     // Get position
     vec2 ipos = floor(uv);
-    
+
     // Return uv as 0 to 1
     uv = fract(uv);
 
@@ -115,31 +125,34 @@ vec3 stars(vec2 uv, float offset) {
     float sparkle = 1. / dot(j, j);
 
     // Set stars to be pure white
-    col += spectrum(fract(rndXY*newRnd*ipos)) * vec3(sparkle);
+    col += spectrum(fract(rndXY * newRnd * ipos)) * vec3(sparkle);
 
     col *= smoothstep(1., 0.8, trans);
     return col; // Return pure white stars only
 }
 
-void mainImage( out vec4 fragColor, in vec2 fragCoord )
+void mainImage(out vec4 fragColor, in vec2 fragCoord)
 {
     // Normalized pixel coordinates (from 0 to 1)
-    vec2 uv = fragCoord/iResolution.xy;
-    
+    vec2 uv = fragCoord / iResolution.xy;
+
     vec3 col = vec3(0.);
-	
-    for (float i = 0.; i < layers; i++ ){
-    	col += stars(uv, i);
+
+    for (float i = 0.; i < layers; i++) {
+        col += stars(uv, i);
     }
 
     // Sample the terminal screen texture including alpha channel
     vec4 terminalColor = texture(iChannel0, uv);
 
+    if (transparent) {
+        col += terminalColor.rgb;
+    }
+
     // Make a mask that is 1.0 where the terminal content is not black
-    float mask = 1 - step(0.5, dot(terminalColor.rgb, vec3(1.0)));
+    float mask = 1 - step(threshold, luminance(terminalColor.rgb));
     vec3 blendedColor = mix(terminalColor.rgb, col, mask);
 
     // Apply terminal's alpha to control overall opacity
     fragColor = vec4(blendedColor, terminalColor.a);
-
 }


### PR DESCRIPTION
- Add transparent background option
- Improved terminal content luminance calculation using luminance formula `0.2126 * R + 0.7152 * G + 0.0722 * B`, which better reflects human visual perception of brightness.
- _formatted using `glsl_analyzer`_

If adding an option is not preferred, I can create a separate file specifically for the transparent version of starfield :)

<img width="862" alt="Screenshot 2025-01-05 at 8 42 57 PM" src="https://github.com/user-attachments/assets/7cb2f187-0cab-482d-a71c-1cc6eb2e10d6" />