### PR TITLE
fix crt.glsl blank output

### DIFF
--- a/crt.glsl
+++ b/crt.glsl
@@ -306,5 +306,5 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     );
 
   // Linear to SRGB for output.
-  fragColor.rgb = ToSrgb(fragColor.rgb);
+  fragColor = vec4(ToSrgb(fragColor.rgb), 1.0);
 }


### PR DESCRIPTION
It wasn't setting an alpha value, so nothing showed up. Fixes #51